### PR TITLE
Remove non-ascii character in runtime.js

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -211,7 +211,7 @@ function Fay$$index(index){
 * Numbers.
 */
 
-// Built-in ×.
+// Built-in *.
 function Fay$$mult(x){
   return function(y){
     return _(x) * _(y);


### PR DESCRIPTION
Using a non-ascii character causes fay to fail on linux systems with the
locale set to POSIX.
