### PR TITLE
implementation of guards

### DIFF
--- a/tests/30
+++ b/tests/30
@@ -1,0 +1,3 @@
+[true,false]
+[2,1,0]
+[true,false]

--- a/tests/30.hs
+++ b/tests/30.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Test where
+
+-- | As pattern matches
+
+import Language.Fay.Prelude
+import Language.Fay.FFI
+
+isPositive :: Double -> Bool
+isPositive x | x > 0 = True
+             | x <= 0 = False
+
+threeConds x | x > 1 = 2
+             | x == 1 = 1
+             | x < 1 = 0
+
+withOtherwise x | x > 1 = True
+                | otherwise = False
+
+-- Not called, throws "non-exhaustive guard"
+nonExhaustive x | x > 1 = True
+
+print :: String -> Fay ()
+print = ffi "console.log(%1)" FayNone
+
+main :: Fay ()
+main = do
+  print $ show $ (isPositive 1, isPositive 0)
+  print $ show $ (threeConds 3, threeConds 1, threeConds 0)
+  print $ show $ (withOtherwise 2, withOtherwise 0)


### PR DESCRIPTION
Here's my attempt at #27. Is it a good start?

It compiles guards into ternary ifs.
If there isn't an `otherwise` present there will be a final alternative that is `throw "Non-exhaustive guards"`. Any conventions on run time errors? I suppose it should at least be `throw new Error()` to produce a stack trace.

I have not matched
      (GuardedRhs _ [] _)
      (GuardedRhs _ ((Generator _ _ _) : _) _)
      (GuardedRhs _ ((LetStmt _) : _) _)
      (GuardedRhs _ ((RecStmt _) : _) _)
are all these possible?
