### PR TITLE
New representation for records + Support for RecDecl (closes #43)

### DIFF
--- a/src/Language/Fay/Print.hs
+++ b/src/Language/Fay/Print.hs
@@ -148,6 +148,8 @@ instance Printable JsExp where
     printJS exp1 ++ " === " ++ printJS exp2
   printJS (JsGetProp exp prop) =
     printJS exp ++ "." ++ printJS prop
+  printJS (JsLookup exp1 exp2) =
+    printJS exp1 ++ "[" ++ printJS exp2 ++ "]"
   printJS (JsUpdateProp name prop expr) =
     (concat ["(",printJS name,".",printJS prop," = ",printJS expr,")"])
   printJS (JsInfix op x y) =

--- a/src/Language/Fay/Types.hs
+++ b/src/Language/Fay/Types.hs
@@ -136,6 +136,7 @@ data JsExp
   | JsSequence [JsExp]
   | JsParen JsExp
   | JsGetProp JsExp JsName
+  | JsLookup JsExp JsExp
   | JsUpdateProp JsExp JsName JsExp
   | JsGetPropExtern JsExp JsName
   | JsUpdatePropExtern JsExp JsName JsExp

--- a/tests/16
+++ b/tests/16
@@ -1,1 +1,4 @@
 Hello!
+Hello!
+Hello!
+Hello!

--- a/tests/16.hs
+++ b/tests/16.hs
@@ -1,7 +1,17 @@
-data Person = Person String String Int
+data Person1 = Person1 String String Int
+data Person2 = Person2 { fname :: String, sname :: String, age :: Int }
+data Person3 = Person3 { slot3 :: String, slot2 :: String, slot1 :: Int }
 
-main = print (case Person "Chris" "Done" 13 of
-                Person "Chris" "Done" 13 -> "Hello!")
+p1  = Person1 "Chris" "Done" 13
+p2  = Person2 "Chris" "Done" 13
+p2a = Person2 { fname = "Chris", sname = "Done", age = 13 }
+p3  = Person3 "Chris" "Done" 13
+
+main = do
+  print (case p1 of Person1 "Chris" "Done" 13 -> "Hello!")
+  print (case p2 of Person2 "Chris" "Done" 13 -> "Hello!")
+  print (case p2a of Person2 "Chris" "Done" 13 -> "Hello!")
+  print (case p3 of Person3 "Chris" "Done" 13 -> "Hello!")
 
 print :: String -> Fay ()
 print = ffi "console.log(%1)"

--- a/tests/33
+++ b/tests/33
@@ -1,0 +1,7 @@
+{ _fields: [ 'i', 'c' ], i: 1, c: 'a' }
+1
+"a"
+{ _fields: [ 'i', 'c' ], i: 2, c: 'b' }
+{ _fields: [ 'i', 'c' ], i: undefined, c: 'b' }
+{ _fields: [ 'i', 'c' ], i: 3, c: 'c' }
+{ _fields: [ 'slot1', 'slot2' ], slot1: 1, slot2: 'a' }

--- a/tests/33.hs
+++ b/tests/33.hs
@@ -1,0 +1,37 @@
+data R = R { i :: Integer, c :: Char }
+data S = S Integer Char
+
+-- RecDecl
+r1 :: R
+r1 = R { i = 1, c = 'a' }
+
+-- RecDecl with fields out of order
+r2 :: R
+r2 = R { c = 'b', i = 2 }
+
+-- Partial RecDecl (Produces GHC warning)
+r' :: R
+r' = R { c = 'b' }
+
+-- Regular application
+r3 :: R
+r3 = R 3 'c'
+
+-- Using regular constructor
+s1 :: S
+s1 = S 1 'a'
+
+main = do
+  print r1
+  printS (show (i r1))
+  printS (show (c r1))
+  print r2
+  print r'
+  print r3
+  print s1
+
+printS :: String -> Fay ()
+printS = ffi "console.log(%1)"
+
+print :: a -> Fay ()
+print = ffi "console.log(%1)"


### PR DESCRIPTION
- Changed the representation of all records to { _fields : ["a","b"], a : _, b : _ }
- Added support for RecDecl as well as pattern matching for it.
- Closes #43
