### PR TITLE
Critical: fay executable now relies on tinfo shared library

### DIFF
--- a/fay.cabal
+++ b/fay.cabal
@@ -158,6 +158,7 @@ executable fay
                      groom,
                      options,
                      haskeline
+  Extra-libraries:   tinfo
 
 executable fay-tests
   if !flag(devel)


### PR DESCRIPTION
This was required for me to link the executable on Fedora 17. Probably the same for CentOS/RedHat.

Running `cabal install` will fail otherwise.
