### PR TITLE
fixed doctype typo

### DIFF
--- a/src/Language/Fay/Compiler.hs
+++ b/src/Language/Fay/Compiler.hs
@@ -40,7 +40,7 @@ compileFromTo config filein fileout = do
       writeFile fileout out
       when (configHtmlWrapper config) $
         writeFile (replaceExtension fileout "html") $ unlines [
-            "<doctype !html>"
+            "<!doctype html>"
           , "<html>"
           , "  <head>"
           , "    <script type=\"text/javascript\" src=\"" ++ relativeJsPath ++ "\">"


### PR DESCRIPTION
pretty small doctype change

```
<doctype !html>
<!doctype html>
```
