### PR TITLE
Make repl try to parse input as declaration too

### DIFF
--- a/src/Language/Fay.hs
+++ b/src/Language/Fay.hs
@@ -17,6 +17,7 @@ module Language.Fay
   ,compileFromStr
   ,compileModule
   ,compileExp
+  ,compileDecl
   ,printCompile
   ,printTestCompile
   ,compileToplevelModule
@@ -324,6 +325,8 @@ compileDecl toplevel decl =
     InstDecl{} -> return [] -- FIXME: Ignore.
     DerivDecl{} -> return []
     _ -> throwError (UnsupportedDeclaration decl)
+
+instance CompilesTo Decl [JsStmt] where compileTo = compileDecl True
 
 -- | Compile a top-level pattern bind.
 compilePatBind :: Bool -> Maybe Type -> Decl -> Compile [JsStmt]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -119,7 +119,15 @@ runInteractive =
             Just input -> do
                 result <- liftIO $ compileViaStr def compileExp input
                 case result of
-                    Left err -> outputStrLn . show $ err
+                    Left err -> do
+                      -- an error occured, maybe input was not an expression,
+                      -- but a declaration, try compiling the input as a declaration
+                      outputStrLn ("can't parse input as expression: " ++ show err)
+                      result' <- liftIO $ compileViaStr def (compileDecl True) input
+                      case result' of
+                        Right (ok,_) -> liftIO (prettyPrintString ok) >>= outputStr
+                        Left err' ->
+                          outputStrLn ("can't parse input as declaration: " ++ show err')
                     Right (ok,_) -> liftIO (prettyPrintString ok) >>= outputStr
                 loop
 


### PR DESCRIPTION
With this patch, Fay REPL also tries to parse user input as a declaration. Before this, it was only working for expressions.
