### PR TITLE
Move import state

### DIFF
--- a/src/Fay/Compiler.hs
+++ b/src/Fay/Compiler.hs
@@ -216,9 +216,9 @@ unlessImported name importFilter importIt = do
     Nothing -> do
       dirs <- configDirectoryIncludePaths <$> config id
       (filepath,contents) <- findImport dirs name
-      res <- importIt filepath contents
                          -- TODO stateImported is already added in initialPass so it is not needed here
                          -- but one Api test fails if it's removed.
       modify $ \s -> s { stateImported     = (name,filepath) : imported
                        }
+      res <- importIt filepath contents
       return res


### PR DESCRIPTION
This seems to preserve all runtime behaviour, but gives a 4x speed up and significant file-size saving.
