### PR TITLE
Object.create workaround in runtime for IE <= 8

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -1,3 +1,12 @@
+// Workaround for missing functionality in IE 8 and earlier.
+if( Object.create === undefined ) {
+	Object.create = function( o ) {
+	    function F(){}
+	    F.prototype = o;
+	    return new F();
+	};
+}
+
 /*******************************************************************************
  * Thunks.
  */


### PR DESCRIPTION
The `Object.create` stuff was your gubbins, is this legit?
