### PR TITLE
Use two space characters for indentation for new IE8 code

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -1,10 +1,10 @@
 // Workaround for missing functionality in IE 8 and earlier.
 if( Object.create === undefined ) {
-	Object.create = function( o ) {
-	    function F(){}
-	    F.prototype = o;
-	    return new F();
-	};
+  Object.create = function( o ) {
+    function F(){}
+    F.prototype = o;
+    return new F();
+  };
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The code for the IE8 workaround used tabs and four spaces for indentation, while the rest of the file used two spaces. This changes the new IE8 code to use two spaces.
