### PR TITLE
Fix type variables in serialization

### DIFF
--- a/src/Fay/Compiler/Decl.hs
+++ b/src/Fay/Compiler/Decl.hs
@@ -84,7 +84,7 @@ compileUnguardedRhs srcloc toplevel ident rhs = do
 
 -- | Compile a data declaration.
 compileDataDecl :: Bool -> Decl -> [QualConDecl] -> Compile [JsStmt]
-compileDataDecl toplevel _decl constructors =
+compileDataDecl toplevel (DataDecl _ _ _ _ tyvars _ _) constructors =
   fmap concat $
     forM constructors $ \(QualConDecl srcloc _ _ condecl) ->
       case condecl of
@@ -93,8 +93,8 @@ compileDataDecl toplevel _decl constructors =
               fields' = (zip (map return fields) types)
           cons <- makeConstructor name fields
           func <- makeFunc name fields
-          emitFayToJs name fields'
-          emitJsToFay name fields'
+          emitFayToJs name tyvars fields'
+          emitJsToFay name tyvars fields'
           emitCons cons
           return [func]
         InfixConDecl t1 name t2 -> do
@@ -102,8 +102,8 @@ compileDataDecl toplevel _decl constructors =
               fields = zip (map return slots) [t1, t2]
           cons <- makeConstructor name slots
           func <- makeFunc name slots
-          emitFayToJs name fields
-          emitJsToFay name fields
+          emitFayToJs name tyvars fields
+          emitJsToFay name tyvars fields
           emitCons cons
           return [func]
         RecDecl name fields' -> do
@@ -111,8 +111,8 @@ compileDataDecl toplevel _decl constructors =
           cons <- makeConstructor name fields
           func <- makeFunc name fields
           funs <- makeAccessors srcloc fields
-          emitFayToJs name fields'
-          emitJsToFay name fields'
+          emitFayToJs name tyvars fields'
+          emitJsToFay name tyvars fields'
           emitCons cons
           return (func : funs)
 


### PR DESCRIPTION
Unfortunately this one cannot be merged as-is because the serialization code has changed since. But the concept is pretty simple. Presently,

```
data Either a b = Left a | Right b
printRight :: Either Int String -> Fay ()
printRight = ffi "console.log(%1)"
```

will not work because the `b` is ignored, the type variable `a` will be indexed in both cases. See commit for how this should be done. I will try to update the new serialization code later if someone else doesn't.
