### PR TITLE
Please, restrict the dependency on language-ecmascript

### DIFF
--- a/fay.cabal
+++ b/fay.cabal
@@ -382,7 +382,7 @@ library
                    , filepath
                    , ghc-paths
                    , haskell-src-exts >= 1.14
-                   , language-ecmascript >= 0.15
+                   , language-ecmascript >= 0.15 && < 1.0
                    , mtl
                    , optparse-applicative >= 0.5
                    , pretty-show >= 1.6
@@ -415,7 +415,7 @@ executable fay
                    , ghc-paths
                    , haskeline
                    , haskell-src-exts >= 1.14
-                   , language-ecmascript >= 0.15
+                   , language-ecmascript >= 0.15 && < 1.0
                    , mtl
                    , optparse-applicative >= 0.5
                    , process
@@ -447,7 +447,7 @@ executable fay-tests
                    , filepath
                    , ghc-paths
                    , haskell-src-exts >= 1.14
-                   , language-ecmascript >= 0.15
+                   , language-ecmascript >= 0.15 && < 1.0
                    , mtl
                    , pretty-show >= 1.6
                    , process


### PR DESCRIPTION
We have had some progress on the the ECMAScript5 branch of `language-ecmascript` and will, hopefully, release it soon, after we're happy with the tests. You are encouraged to switch to the ECMAScript5 parser when it's released. However, it won't be compatible with the current version and _will_ break your builds.
My plan is to retire the ECMAScript3 branch altogether. The plan is to release the new ECMAScript5 together with the current ECMAScript3 versions of the library as version 0.16 (or, maybe, 0.17 in case I need to issue another maintenance release in the mean-time). There will be deprecation notices for ECMAScript3 in that version.
Version 1.0 will drop the ECMAScript3 branch _entirely_ and _will_ break your build so, until you switch to ECMAScript5, please, make sure you don't depend on 1.0 and upward. I'm submitting changes to fay.cabal that, hopefully, would prevent me from breaking your builds in the near future.
