### PR TITLE
Fix extra </script> tag in HTML wrapper

### DIFF
--- a/src/Fay.hs
+++ b/src/Fay.hs
@@ -71,7 +71,6 @@ compileFromToAndGenerateHtml config filein fileout = do
           ,"    <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>"
           , unlines . map (("    "++) . makeScriptTagSrc) $ configHtmlJSLibs config
           , "    " ++ makeScriptTagSrc relativeJsPath
-          , "    </script>"
           , "  </head>"
           , "  <body>"
           , "  </body>"


### PR DESCRIPTION
It's not needed -- the closing tags are added automatically.
