### PR TITLE
Don't cache the main thunk and add test case

### DIFF
--- a/src/Fay.hs
+++ b/src/Fay.hs
@@ -144,7 +144,7 @@ compileToModule filepath config raw with hscode = do
       ,jscode
       ,if not (configLibrary config)
           then unlines [";"
-                       ,"Fay$$_(" ++ modulename ++ ".main);"
+                       ,"Fay$$_(" ++ modulename ++ ".main,true);"
                        ]
           else ""
       ]

--- a/tests/MainThunk.hs
+++ b/tests/MainThunk.hs
@@ -1,0 +1,10 @@
+import FFI
+
+main = do putStrLn "Hey ho!"
+          setTimeout 500 doThing
+          doThing
+
+doThing = putStrLn "Hello, World!"
+
+setTimeout :: Int -> (Fay ()) -> Fay ()
+setTimeout = ffi "(function (f,i) { var id = setTimeout(function () { f(id); }, i); return id; })(%2,%1)"

--- a/tests/MainThunk.res
+++ b/tests/MainThunk.res
@@ -1,0 +1,3 @@
+Hey ho!
+Hello, World!
+Hello, World!


### PR DESCRIPTION
I think I never set the `true` (meaning no-cache) in main just because I never realised this case would happen, and clearly nobody noticed. A workaround is to add a dummy arg to `doThing` like `()`, but this is the proper fix.
