### PR TITLE
Fallback to ghc and ghc-pkg in PATH if not available from GHC.Paths

### DIFF
--- a/src/Fay/Compiler/Packages.hs
+++ b/src/Fay/Compiler/Packages.hs
@@ -55,7 +55,8 @@ doesSourceDirExist path = do
 -- | Describe the given package.
 describePackage :: Maybe FilePath -> String -> IO String
 describePackage db name = do
-  result <- readAllFromProcess ghc_pkg args ""
+  exists <- doesFileExist ghc_pkg
+  result <- readAllFromProcess (if exists then ghc_pkg else "ghc-pkg") args ""
   case result of
     Left  (err,out) -> error $ "ghc-pkg describe error:\n" ++ err ++ "\n" ++ out
     Right (_err,out) -> return out

--- a/src/Fay/Compiler/Typecheck.hs
+++ b/src/Fay/Compiler/Typecheck.hs
@@ -11,6 +11,8 @@ import           Fay.Types
 
 import qualified GHC.Paths             as GHCPaths
 
+import           System.Directory
+
 -- | Call out to GHC to type-check the file.
 typecheck :: Config -> FilePath -> IO (Either CompileError String)
 typecheck cfg fp = do
@@ -37,7 +39,8 @@ typecheck cfg fp = do
           , "Language.Fay.DummyMain"
           , "-i" ++ intercalate ":" includeDirs
           , fp ] ++ ghcPackageDbArgs ++ wallF ++ map ("-package " ++) packages
-  res <- readAllFromProcess GHCPaths.ghc flags ""
+  exists <- doesFileExist GHCPaths.ghc
+  res <- readAllFromProcess (if exists then GHCPaths.ghc else "ghc") flags ""
   either (return . Left . GHCError . fst) (return . Right . fst) res
    where
     wallF | configWall cfg = ["-Wall"]


### PR DESCRIPTION
We have this use-case where the Fay library is compiled in one place but run on another machine where the `ghc`/`ghc-pkg` are not in the `GHC.Paths` location but are in `PATH`. This should handle that.
