### PR TITLE
Hide all packages by default, auto-enable fay-base

### DIFF
--- a/src/Fay/Compiler/Typecheck.hs
+++ b/src/Fay/Compiler/Typecheck.hs
@@ -31,7 +31,7 @@ typecheck cfg fp = do
         return [flag ++ '=' : pk]
   let flags =
           [ "-fno-code"
-          , "-hide-package base"
+          , "-hide-all-packages"
           , "-cpp", "-pgmPcpphs", "-optP--cpp"
           , "-optP-C" -- Don't let hse-cpp remove //-style comments.
           , "-DFAY=1"


### PR DESCRIPTION
This avoids conflicting with packages that haven't been specified on
the command-line with --package, e.g. the text package when you import
Data.Text.
