### PR TITLE
De/serialize type variables as 'automatic'; #424

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -235,8 +235,10 @@ function Fay$$fayToJs(type,fayObj){
     // Bools are unboxed.
     return Fay$$_(fayObj);
   }
-  else if(base == "ptr" || base == "unknown")
+  else if(base == "ptr")
     return fayObj;
+  else if(base == "unknown")
+    return Fay$$fayToJs(["automatic"], fayObj);
   else if(base == "automatic" && fayObj instanceof Function) {
     return Fay$$fayToJs(["function", "automatic_function"], fayObj);
   }
@@ -384,10 +386,11 @@ function Fay$$jsToFay(type,jsObj){
   }
   else if (base == "double" ||
            base == "bool" ||
-           base ==  "ptr" ||
-           base ==  "unknown") {
+           base ==  "ptr") {
     return jsObj;
   }
+  else if(base == "unknown")
+    return Fay$$jsToFay(["automatic"], jsObj);
   else if(base == "automatic" && jsObj instanceof Function) {
     var type = [["automatic"]];
     for (var i = 0; i < jsObj.length; i++)

--- a/tests/serialization.hs
+++ b/tests/serialization.hs
@@ -11,8 +11,8 @@ main = do
   printMaybeConcrete (Just (ConcreteRecord 42))
   printMaybeAutomatic (Just (ConcreteRecord 42))
   printMaybe (Just (ConcreteRecord 42))
-  printUnknown (error "do not want")
-  printUnknownField (Just (error "do not want"))
+  printUnknown 42
+  printUnknownField (Just 42)
   printAutomatic (Just (ConcreteRecord 42))
 
 printParametricButConcreteType :: Parametric ConcreteRecord -> Fay ()

--- a/tests/serialization.res
+++ b/tests/serialization.res
@@ -3,15 +3,14 @@
 { instance: 'Parametric',
   slot1: { instance: 'ConcreteRecord', concreteField: 123 } }
 { instance: 'Parametric',
-  slot1: { forced: false, value: [Function] } }
+  slot1: { instance: 'ConcreteRecord', concreteField: 123 } }
 { instance: 'Just',
   slot1: { instance: 'ConcreteRecord', concreteField: 42 } }
 { instance: 'Just',
   slot1: { instance: 'ConcreteRecord', concreteField: 42 } }
 { instance: 'Just',
-  slot1: { forced: false, value: [Function] } }
-{ forced: false, value: [Function] }
-{ instance: 'Just',
-  slot1: { forced: false, value: [Function] } }
+  slot1: { instance: 'ConcreteRecord', concreteField: 42 } }
+42
+{ instance: 'Just', slot1: 42 }
 { instance: 'Just',
   slot1: { instance: 'ConcreteRecord', concreteField: 42 } }


### PR DESCRIPTION
Updated the de/serialization of `a` to use "automatic"

I needed to make more changes to the serialization.hs test than I originally expected. The issues seemed to be related to strictness rather than serialization. The previous version seemed to expect `a ->` to indicate less strictness than use of concrete types. While it seems overall evaluation may be too strict, I wouldn't expect it to vary based on whether the type is static.

One thing I observed that I would like to try to understand is how changes in runtime.js can cause changes in the generated callsite code. The previous serialization.js contained many instances of `$36$uncurried$36$uncurried` that then were no longer present after updating runtime.js.