### PR TITLE
Update fay to run with more recent haskell-src-exts

### DIFF
--- a/fay-language-ecmascript.diff
+++ b/fay-language-ecmascript.diff
@@ -1,0 +1,167 @@
+diff --git a/CHANGELOG b/CHANGELOG
+index 857e529..0902a89 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,9 +1,4 @@
+ Version change log.
+-=0.18.1=
+-Moved dependency on test-feat from src to test.  Removed tabs.
+-	
+-=0.18=
+-Pull request #83: Updated dependencies, migrated to ansi-wl-pprint.
+ 
+ =0.17.2.0=
+ Issue #82: Tighter lexing of identifiers using Unicode character classes (thanks @berdario).
+diff --git a/language-ecmascript.cabal b/language-ecmascript.cabal
+index e5de214..c9b9633 100644
+--- a/language-ecmascript.cabal
++++ b/language-ecmascript.cabal
+@@ -1,6 +1,6 @@
+ Name:           language-ecmascript
+-Version:        0.18.1
+-Cabal-Version:	>= 1.10.0.1
++Version:        0.18
++Cabal-Version:	>= 1.10
+ Copyright:      (c) 2007-2012 Brown University, (c) 2008-2010 Claudiu Saftoiu,
+                 (c) 2012-2015 Stevens Institute of Technology, (c) 2016 Eyal Lotem, (c) 2016-2017 Andrey Chudnov
+ License:        BSD3
+@@ -29,7 +29,7 @@ Source-repository head
+ Source-repository this
+    type: git
+    location: git://github.com/jswebtools/language-ecmascript.git
+-   tag: 0.18
++   tag: 0.17.2.0
+ 
+ Library
+   Hs-Source-Dirs:
+@@ -45,6 +45,7 @@ Library
+     QuickCheck >= 2.5 && < 3,
+     template-haskell >= 2.7 && < 3,
+     Diff == 0.3.*,
++    testing-feat >= 0.4.0.2 && < 1.1,
+     charset >= 0.3
+   ghc-options:
+     -fwarn-incomplete-patterns
+@@ -55,6 +56,7 @@ Library
+     Language.ECMAScript3.PrettyPrint
+     Language.ECMAScript3.Syntax
+     Language.ECMAScript3.Syntax.Annotations
++    Language.ECMAScript3.Syntax.Arbitrary
+     Language.ECMAScript3.Syntax.CodeGen
+     Language.ECMAScript3.Syntax.QuasiQuote
+     Language.ECMAScript3.Analysis.Environment
+@@ -68,19 +70,10 @@ Library
+   Default-Language: Haskell2010
+ 
+ Test-Suite test
+-  Hs-Source-Dirs: src test
++  Hs-Source-Dirs: test
+   Type: exitcode-stdio-1.0
+   Main-Is: TestMain.hs
+   Other-Modules:
+-    Language.ECMAScript3.Lexer                                        
+-    Language.ECMAScript3.Parser                                       
+-    Language.ECMAScript3.Parser.State                                 
+-    Language.ECMAScript3.Parser.Type                                  
+-    Language.ECMAScript3.PrettyPrint                                  
+-    Language.ECMAScript3.SourceDiff                                   
+-    Language.ECMAScript3.Syntax                                       
+-    Language.ECMAScript3.Syntax.Annotations  
+-    Language.ECMAScript3.Syntax.Arbitrary
+     Test.Diff
+     Test.Unit
+     Test.Pretty
+@@ -90,14 +83,12 @@ Test-Suite test
+     mtl >= 1 && < 3,
+     parsec >= 3 && < 3.2.0,
+     ansi-wl-pprint >= 0.6 && < 1,
+-    charset >= 0.3,
+     containers == 0.*,
+     directory >= 1.2 && < 1.4,
+     filepath >= 1.3 && < 1.5,
+     HUnit >= 1.2 && < 1.7,
+     QuickCheck >= 2.5 && < 3,
+     data-default-class >= 0.0.1 && < 0.2,
+-    testing-feat >= 0.4.0.2 && < 1.1,
+     test-framework >= 0.8 && < 0.9,
+     test-framework-hunit >= 0.3.0 && < 0.4,
+     test-framework-quickcheck2 >= 0.3.0.1 && < 0.4,
+diff --git a/src/Language/ECMAScript3/Lexer.hs b/src/Language/ECMAScript3/Lexer.hs
+index c23ceb1..cc22604 100644
+--- a/src/Language/ECMAScript3/Lexer.hs
++++ b/src/Language/ECMAScript3/Lexer.hs
+@@ -80,45 +80,45 @@ lex = T.makeTokenParser javascriptDef
+ 
+ -- everything but commaSep and semiSep
+ identifier :: Stream s Identity Char => Parser s String
+-identifier = T.identifier  lex
++identifier = T.identifier	 lex
+ reserved :: Stream s Identity Char => String -> Parser s ()
+-reserved = T.reserved  lex
++reserved = T.reserved	 lex
+ operator :: Stream s Identity Char => Parser s String
+-operator = T.operator  lex
++operator = T.operator	 lex
+ reservedOp :: Stream s Identity Char => String -> Parser s ()
+-reservedOp = T.reservedOp lex 
++reservedOp = T.reservedOp lex	
+ charLiteral :: Stream s Identity Char => Parser s Char
+-charLiteral = T.charLiteral lex 
++charLiteral = T.charLiteral lex	
+ stringLiteral :: Stream s Identity Char => Parser s String
+ stringLiteral = T.stringLiteral lex
+ -- natural :: Stream s Identity Char => Parser s Integer
+--- natural = T.natural lex 
++-- natural = T.natural lex	
+ -- integer :: Stream s Identity Char => Parser s Integer
+--- integer = T.integer lex 
++-- integer = T.integer lex	
+ -- float :: Stream s Identity Char => Parser s Double
+ -- float = T.float lex
+ -- naturalOrFloat :: Stream s Identity Char => Parser s (Either Integer Double)
+ -- naturalOrFloat = T.naturalOrFloat lex
+ -- decimal :: Stream s Identity Char => Parser s Integer
+--- decimal = T.decimal lex 
++-- decimal = T.decimal lex	
+ -- hexadecimal :: Stream s Identity Char => Parser s Integer
+--- hexadecimal = T.hexadecimal lex 
++-- hexadecimal = T.hexadecimal lex	
+ -- octal :: Stream s Identity Char => Parser s Integer
+ -- octal = T.octal lex
+ symbol :: Stream s Identity Char => String -> Parser s String
+ symbol = T.symbol lex
+ whiteSpace :: Stream s Identity Char => Parser s ()
+-whiteSpace = T.whiteSpace lex 
++whiteSpace = T.whiteSpace lex	
+ parens :: Stream s Identity Char => Parser s a -> Parser s a
+-parens = T.parens  lex
++parens = T.parens	 lex
+ braces :: Stream s Identity Char => Parser s a -> Parser s a
+-braces = T.braces  lex
++braces = T.braces	 lex
+ squares :: Stream s Identity Char => Parser s a -> Parser s a
+-squares = T.squares lex 
++squares = T.squares lex	
+ semi :: Stream s Identity Char => Parser s String
+-semi = T.semi  lex
++semi = T.semi	 lex
+ comma :: Stream s Identity Char => Parser s String
+-comma = T.comma  lex
++comma = T.comma	 lex
+ colon :: Stream s Identity Char => Parser s String
+ colon = T.colon lex
+ dot :: Stream s Identity Char => Parser s String
+diff --git a/stack.yaml b/stack.yaml
+index 6ee7919..d63504e 100644
+--- a/stack.yaml
++++ b/stack.yaml
+@@ -1,8 +1,7 @@
+ # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+ 
+ # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+-# resolver: lts-8.22
+-resolver: lts-11.4
++resolver: lts-8.22
+ 
+ # Local packages, usually specified by relative directory name
+ packages:

--- a/fay.cabal
+++ b/fay.cabal
@@ -1,218 +1,217 @@
-name:                fay
-version:             0.24.0.1
-synopsis:            A compiler for Fay, a Haskell subset that compiles to JavaScript.
-description:         Fay is a proper subset of Haskell which is type-checked
-                     with GHC, and compiled to JavaScript. It is lazy, pure, has a Fay monad,
-                     an FFI, tail-recursion optimization (experimental), and support for cabal packages.
-                     .
-                     /Documentation/
-                     .
-                     See <https://github.com/faylang/fay/wiki>
-                     .
-                     /Examples/
-                     .
-                     See the examples directory and <https://github.com/faylang/fay/wiki#fay-in-the-wild>
-                     .
-homepage:            https://github.com/faylang/fay/wiki
-bug-reports:         https://github.com/faylang/fay/issues
-license:             BSD3
-license-file:        LICENSE
-author:              Chris Done, Adam Bergmark
-maintainer:          adam@bergmark.nl
-copyright:           2012 Chris Done, Adam Bergmark
-category:            Development, Web, Fay
-build-type:          Custom
-cabal-version:       >=1.8
+cabal-version: >=1.8
+name: fay
+version: 0.24.0.1
+license: BSD3
+license-file: LICENSE
+copyright: 2012 Chris Done, Adam Bergmark
+maintainer: adam@bergmark.nl
+author: Chris Done, Adam Bergmark
+homepage: https://github.com/faylang/fay/wiki
+bug-reports: https://github.com/faylang/fay/issues
+synopsis: A compiler for Fay, a Haskell subset that compiles to JavaScript.
+description:
+    Fay is a proper subset of Haskell which is type-checked
+    with GHC, and compiled to JavaScript. It is lazy, pure, has a Fay monad,
+    an FFI, tail-recursion optimization (experimental), and support for cabal packages.
+    .
+    /Documentation/
+    .
+    See <https://github.com/faylang/fay/wiki>
+    .
+    /Examples/
+    .
+    See the examples directory and <https://github.com/faylang/fay/wiki#fay-in-the-wild>
+    .
+category: Development, Web, Fay
+build-type: Custom
 data-files:
-  src/Fay/FFI.hs
+    src/Fay/FFI.hs
 extra-source-files:
-  CHANGELOG.md
-  LICENSE
-  README.md
-  src/haskell-names/LICENSE
-  -- Examples
-  examples/*.hs
-  examples/*.html
-  examples/*.png
-  -- Test cases
-  tests/*.hs
-  tests/*.res
-  tests/Compile/*.hs
-  tests/Compile/*.res
-  tests/FromString/*.hs
-  tests/FromString/*.res
-  tests/Hierarchical/*.hs
-  tests/Hierarchical/*.res
-  tests/ImportList1/*.hs
-  tests/ImportList1/*.res
-  tests/ImportType2I/*.hs
-  tests/ImportType2I/*.res
-  tests/Issue215/*.hs
-  tests/Issue215/*.res
-  tests/ModuleReExport/*.hs
-  tests/ModuleReExport/*.res
-  tests/ModuleRecordClash/*.hs
-  tests/ModuleRecordClash/*.res
-  tests/NestedImporting/*.hs
-  tests/NestedImporting/*.res
-  tests/NestedImporting2/*.hs
-  tests/NestedImporting2/*.res
-  tests/QualifiedImport/*.hs
-  tests/QualifiedImport/*.res
-  tests/ReExportGlobally/*.hs
-  tests/ReExportGlobally/*.res
+    CHANGELOG.md
+    LICENSE
+    README.md
+    src/haskell-names/LICENSE
+    examples/*.hs
+    examples/*.html
+    examples/*.png
+    tests/*.hs
+    tests/*.res
+    tests/Compile/*.hs
+    tests/Compile/*.res
+    tests/FromString/*.hs
+    tests/FromString/*.res
+    tests/Hierarchical/*.hs
+    tests/Hierarchical/*.res
+    tests/ImportList1/*.hs
+    tests/ImportList1/*.res
+    tests/ImportType2I/*.hs
+    tests/ImportType2I/*.res
+    tests/Issue215/*.hs
+    tests/Issue215/*.res
+    tests/ModuleReExport/*.hs
+    tests/ModuleReExport/*.res
+    tests/ModuleRecordClash/*.hs
+    tests/ModuleRecordClash/*.res
+    tests/NestedImporting/*.hs
+    tests/NestedImporting/*.res
+    tests/NestedImporting2/*.hs
+    tests/NestedImporting2/*.res
+    tests/QualifiedImport/*.hs
+    tests/QualifiedImport/*.res
+    tests/ReExportGlobally/*.hs
+    tests/ReExportGlobally/*.res
 
 source-repository head
-  type: git
-  location: https://github.com/faylang/fay.git
-
-flag test
-  description:       Build the fay-tests executable
-  manual:            True
-  default:           False
+    type: git
+    location: https://github.com/faylang/fay.git
 
 custom-setup
-  setup-depends:
-      base
-    , Cabal
+    setup-depends: base -any,
+                   Cabal -any
+
+flag test
+    description:
+        Build the fay-tests executable
+    default: False
+    manual: True
 
 library
-  ghc-options:       -O2 -Wall
-  hs-source-dirs:
-    src
-    src/haskell-names
-  exposed-modules:
-    Fay
-    Fay.Compiler
-    Fay.Compiler.Desugar
-    Fay.Compiler.Parse
-    Fay.Compiler.Prelude
-    Fay.Config
-    Fay.Convert
-    Fay.FFI
-    Fay.Types
-    Fay.Types.CompileError
-    Fay.Types.CompileResult
-  other-modules:
-    Fay.Compiler.Decl
-    Fay.Compiler.Defaults
-    Fay.Compiler.Desugar.Name
-    Fay.Compiler.Desugar.Types
-    Fay.Compiler.Exp
-    Fay.Compiler.FFI
-    Fay.Compiler.GADT
-    Fay.Compiler.Import
-    Fay.Compiler.InitialPass
-    Fay.Compiler.Misc
-    Fay.Compiler.ModuleT
-    Fay.Compiler.Optimizer
-    Fay.Compiler.Packages
-    Fay.Compiler.Pattern
-    Fay.Compiler.PrimOp
-    Fay.Compiler.Print
-    Fay.Compiler.QName
-    Fay.Compiler.State
-    Fay.Compiler.Typecheck
-    Fay.Exts
-    Fay.Exts.NoAnnotation
-    Fay.Exts.Scoped
-    Fay.Runtime
-    Fay.Types.FFI
-    Fay.Types.Js
-    Fay.Types.ModulePath
-    Fay.Types.Printer
-    Language.Haskell.Names
-    Language.Haskell.Names.Annotated
-    Language.Haskell.Names.Exports
-    Language.Haskell.Names.GetBound
-    Language.Haskell.Names.GlobalSymbolTable
-    Language.Haskell.Names.Imports
-    Language.Haskell.Names.LocalSymbolTable
-    Language.Haskell.Names.ModuleSymbols
-    Language.Haskell.Names.Open.Base
-    Language.Haskell.Names.Open.Derived
-    Language.Haskell.Names.Open.Instances
-    Language.Haskell.Names.RecordWildcards
-    Language.Haskell.Names.Recursive
-    Language.Haskell.Names.ScopeUtils
-    Language.Haskell.Names.SyntaxUtils
-    Language.Haskell.Names.Types
-    Paths_fay
-  build-depends:
-      base >= 4.9
-    , base-compat >= 0.8
-    , aeson > 0.6
-    , bytestring >= 0.9
-    , containers >= 0.4
-    , data-default >= 0.2
-    , data-lens-light == 0.1.*
-    , directory >= 1.1
-    , filepath >= 1.3
-    , ghc-paths == 0.1.*
---    , haskell-src-exts >= 1.18.1 && <1.20
-    , haskell-src-exts >= 1.18.1
-    , language-ecmascript >= 0.15
-    , mtl >= 2.1
-    , mtl-compat >= 0.1
-    , process >= 1.1
-    , safe >= 0.2
-    , sourcemap == 0.1.*
-    , split >= 0.1
-    , spoon >= 0.1
-    , syb >= 0.3
-    , text >= 0.11
-    , time >= 1.4
-    , transformers >= 0.3
-    , transformers-compat >= 0.3
-    , traverse-with-class >= 1.0
-    , uniplate >= 1.6.11
-    , unordered-containers == 0.2.*
-    , utf8-string >= 0.1
-    , vector < 0.13
-    , shakespeare
-
-  if impl(ghc < 7.8)
-    build-depends: tagged
+    exposed-modules:
+        Fay
+        Fay.Compiler
+        Fay.Compiler.Desugar
+        Fay.Compiler.Parse
+        Fay.Compiler.Prelude
+        Fay.Config
+        Fay.Convert
+        Fay.FFI
+        Fay.Types
+        Fay.Types.CompileError
+        Fay.Types.CompileResult
+    hs-source-dirs: src src/haskell-names
+    other-modules:
+        Fay.Compiler.Decl
+        Fay.Compiler.Defaults
+        Fay.Compiler.Desugar.Name
+        Fay.Compiler.Desugar.Types
+        Fay.Compiler.Exp
+        Fay.Compiler.FFI
+        Fay.Compiler.GADT
+        Fay.Compiler.Import
+        Fay.Compiler.InitialPass
+        Fay.Compiler.Misc
+        Fay.Compiler.ModuleT
+        Fay.Compiler.Optimizer
+        Fay.Compiler.Packages
+        Fay.Compiler.Pattern
+        Fay.Compiler.PrimOp
+        Fay.Compiler.Print
+        Fay.Compiler.QName
+        Fay.Compiler.State
+        Fay.Compiler.Typecheck
+        Fay.Exts
+        Fay.Exts.NoAnnotation
+        Fay.Exts.Scoped
+        Fay.Runtime
+        Fay.Types.FFI
+        Fay.Types.Js
+        Fay.Types.ModulePath
+        Fay.Types.Printer
+        Language.Haskell.Names
+        Language.Haskell.Names.Annotated
+        Language.Haskell.Names.Exports
+        Language.Haskell.Names.GetBound
+        Language.Haskell.Names.GlobalSymbolTable
+        Language.Haskell.Names.Imports
+        Language.Haskell.Names.LocalSymbolTable
+        Language.Haskell.Names.ModuleSymbols
+        Language.Haskell.Names.Open.Base
+        Language.Haskell.Names.Open.Derived
+        Language.Haskell.Names.Open.Instances
+        Language.Haskell.Names.RecordWildcards
+        Language.Haskell.Names.Recursive
+        Language.Haskell.Names.ScopeUtils
+        Language.Haskell.Names.SyntaxUtils
+        Language.Haskell.Names.Types
+        Paths_fay
+    ghc-options: -O2 -Wall
+    build-depends:
+        base >=4.9 && <4.12,
+        base-compat >=0.8 && <0.11,
+        aeson >0.6 && <1.4,
+        bytestring >=0.9 && <0.11,
+        containers >=0.4 && <0.6,
+        data-default >=0.2 && <0.8,
+        data-lens-light ==0.1.*,
+        directory >=1.1 && <1.4,
+        filepath >=1.3 && <1.5,
+        ghc-paths ==0.1.*,
+        haskell-src-exts >=1.18.1 && <1.21,
+        language-ecmascript >=0.15 && <0.19,
+        mtl >=2.1 && <2.3,
+        mtl-compat >=0.1 && <0.3,
+        process >=1.1 && <1.7,
+        safe >=0.2 && <0.4,
+        sourcemap ==0.1.*,
+        split >=0.1 && <0.3,
+        spoon >=0.1 && <0.4,
+        syb >=0.3 && <0.8,
+        text >=0.11 && <1.3,
+        time >=1.4 && <1.9,
+        transformers >=0.3 && <0.6,
+        transformers-compat >=0.3 && <0.7,
+        traverse-with-class ==1.0.*,
+        uniplate >=1.6.11 && <1.7,
+        unordered-containers ==0.2.*,
+        utf8-string >=0.1 && <1.1,
+        vector <0.13,
+        shakespeare <2.1
+    
+    if impl(ghc <7.8)
+        build-depends:
+            tagged <0.9
 
 executable fay
-  hs-source-dirs:    src/main
-  ghc-options:       -O2 -Wall
-  main-is:           Main.hs
-  build-depends:
-      base
-    , fay
-    , mtl
-    , optparse-applicative >= 0.11
-    , split
-  other-modules:
-    Paths_fay
-executable fay-tests
-  ghc-options:       -O2 -Wall -threaded -with-rtsopts=-N
-  hs-source-dirs:    src/tests
-  main-is:           Tests.hs
-  if flag(test)
+    main-is: Main.hs
+    hs-source-dirs: src/main
     other-modules:
-      Test.CommandLine
-      Test.Compile
-      Test.Convert
-      Test.Desugar
-      Test.Util
-      Paths_fay
+        Paths_fay
+    ghc-options: -O2 -Wall
     build-depends:
-        base
-      , aeson
-      , attoparsec
-      , bytestring
-      , containers
-      , directory
-      , fay
-      , filepath
-      , haskell-src-exts
-      , random >= 1.0
-      , tasty >= 0.9
-      , tasty-hunit >= 0.8
-      , tasty-th == 0.1.*
-      , text
-      , utf8-string
-  else
-    buildable:         True
+        base <4.12,
+        fay -any,
+        mtl <2.3,
+        optparse-applicative >=0.11 && <0.15,
+        split <0.3
+
+executable fay-tests
+    main-is: Tests.hs
+    hs-source-dirs: src/tests
+    ghc-options: -O2 -Wall -threaded -with-rtsopts=-N
+    
+    if flag(test)
+        other-modules:
+            Test.CommandLine
+            Test.Compile
+            Test.Convert
+            Test.Desugar
+            Test.Util
+            Paths_fay
+        build-depends:
+            base -any,
+            aeson -any,
+            attoparsec -any,
+            bytestring -any,
+            containers -any,
+            directory -any,
+            fay -any,
+            filepath -any,
+            haskell-src-exts -any,
+            random >=1.0,
+            tasty >=0.9,
+            tasty-hunit >=0.8,
+            tasty-th ==0.1.*,
+            text -any,
+            utf8-string -any
+    else
+      buildable:         False

--- a/fay.cabal
+++ b/fay.cabal
@@ -1,5 +1,5 @@
 name:                fay
-version:             0.24.0.0
+version:             0.24.0.1
 synopsis:            A compiler for Fay, a Haskell subset that compiles to JavaScript.
 description:         Fay is a proper subset of Haskell which is type-checked
                      with GHC, and compiled to JavaScript. It is lazy, pure, has a Fay monad,
@@ -139,34 +139,35 @@ library
     Language.Haskell.Names.Types
     Paths_fay
   build-depends:
-      base >= 4.9 && < 4.11
-    , base-compat >= 0.8 && < 0.10
-    , aeson > 0.6 && < 1.4
-    , bytestring >= 0.9 && < 0.11
-    , containers >= 0.4 && < 0.6
-    , data-default >= 0.2 && < 0.8
+      base >= 4.9
+    , base-compat >= 0.8
+    , aeson > 0.6
+    , bytestring >= 0.9
+    , containers >= 0.4
+    , data-default >= 0.2
     , data-lens-light == 0.1.*
-    , directory >= 1.1 && < 1.4
-    , filepath >= 1.3 && < 1.5
+    , directory >= 1.1
+    , filepath >= 1.3
     , ghc-paths == 0.1.*
-    , haskell-src-exts >= 1.18.1 && < 1.20
-    , language-ecmascript >= 0.15 && < 0.18
-    , mtl >= 2.1 && < 2.3
-    , mtl-compat >= 0.1 && < 0.3
-    , process >= 1.1 && < 1.7
-    , safe >= 0.2 && < 0.4
+--    , haskell-src-exts >= 1.18.1 && <1.20
+    , haskell-src-exts >= 1.18.1
+    , language-ecmascript >= 0.15
+    , mtl >= 2.1
+    , mtl-compat >= 0.1
+    , process >= 1.1
+    , safe >= 0.2
     , sourcemap == 0.1.*
-    , split >= 0.1 && < 0.3
-    , spoon >= 0.1 && < 0.4
-    , syb >= 0.3 && < 0.8
-    , text >= 0.11 && < 1.3
-    , time >= 1.4 && < 1.9
-    , transformers >= 0.3 && < 0.4 || > 0.4.1 && < 0.7
-    , transformers-compat >= 0.3 && < 0.7
-    , traverse-with-class >= 1.0 && < 1.1
-    , uniplate >= 1.6.11 && < 1.7
+    , split >= 0.1
+    , spoon >= 0.1
+    , syb >= 0.3
+    , text >= 0.11
+    , time >= 1.4
+    , transformers >= 0.3
+    , transformers-compat >= 0.3
+    , traverse-with-class >= 1.0
+    , uniplate >= 1.6.11
     , unordered-containers == 0.2.*
-    , utf8-string >= 0.1 && < 1.1
+    , utf8-string >= 0.1
     , vector < 0.13
     , shakespeare
 
@@ -181,7 +182,7 @@ executable fay
       base
     , fay
     , mtl
-    , optparse-applicative >= 0.11 && < 0.15
+    , optparse-applicative >= 0.11
     , split
   other-modules:
     Paths_fay
@@ -207,11 +208,11 @@ executable fay-tests
       , fay
       , filepath
       , haskell-src-exts
-      , random >= 1.0 && < 1.2
-      , tasty >= 0.9 && < 1.1
-      , tasty-hunit >= 0.8 && < 0.11
+      , random >= 1.0
+      , tasty >= 0.9
+      , tasty-hunit >= 0.8
       , tasty-th == 0.1.*
       , text
       , utf8-string
   else
-    buildable:         False
+    buildable:         True

--- a/pullRequest.txt
+++ b/pullRequest.txt
@@ -1,0 +1,29 @@
+Hi Adam,
+
+I have quite of bit of code that depends on fay, so when it doesn't
+compile with the version of ghc I'm using, I notice.  Well, I couldn't
+compile fay with ghc 8.4.2 so I started looking into it.  I discovered
+that the culprits where mainly two.  The new Semigroup class and some
+new names introduced to haskell-src-exts.  So I added those changes to
+fay and found I still couldn't compile because of dependency on
+testing-feat in language-ecmascript.  It turns out that testing-feat
+is not really required to compile the language, it is just need to run
+the tests.  I modified the language-ecmascript.cabal file to pull out
+the testing-feat dependency and put it into the test section of the
+cabal file and filed a pull request,
+https://github.com/jswebtools/language-ecmascript/pull/84, almost a
+month ago.  Sadly it has not yet been included in Hackage so I have to
+have my own private version of language-ecmascript in order to compile
+fay.  I'm included the file fay-language-ecmascript.diff in this pull
+request so perhaps you can encourage Andrey
+(https://github.com/achudnov) to push it to hackage.  Anyway, after
+making all those changes, it now compiles and passes the tests with
+nightly-2018-05-13.  I was hoping an lts package that uses ghc 8.4.2
+becomes available before I sent this, but so far it hasn't and I need
+to move on to other things.  I wish I understood the code you have
+written to implement fay better, but it is above my haskell pay grade
+at this point.  Anyway, I hope you find this effort helpful in keeping
+fay up to date.
+
+Best wishes,
+Henry Laxen

--- a/src/Fay/Types.hs
+++ b/src/Fay/Types.hs
@@ -60,6 +60,7 @@ import           Control.Monad.RWS
 import           Data.Map                (Map)
 import           Data.Set                (Set)
 import           Language.Haskell.Names  (Symbols)
+import           Data.Semigroup          (Semigroup)
 
 --------------------------------------------------------------------------------
 -- Compiler types
@@ -85,6 +86,11 @@ data CompileWriter = CompileWriter
   , writerFayToJs :: [(String,JsExp)] -- ^ Fay to JS dispatchers.
   , writerJsToFay :: [(String,JsExp)] -- ^ JS to Fay dispatchers.
   } deriving (Show)
+
+-- | Simple concatenating instance.
+instance Semigroup CompileWriter where
+  (CompileWriter a b c) <> (CompileWriter x y z) =
+    CompileWriter (a++x) (b++y) (c++z)
 
 -- | Simple concatenating instance.
 instance Monoid CompileWriter where

--- a/src/Fay/Types/Printer.hs
+++ b/src/Fay/Types/Printer.hs
@@ -22,6 +22,7 @@ import Data.Maybe                      (fromMaybe)
 import Data.String
 import Language.Haskell.Exts
 import SourceMap.Types
+import qualified Data.Semigroup as SG
 
 -- | Global options of the printer
 data PrintReader = PrintReader
@@ -43,10 +44,12 @@ data PrintWriter = PrintWriter
 pwOutputString :: PrintWriter -> String
 pwOutputString (PrintWriter _ out) = out ""
 
+instance SG.Semigroup PrintWriter where
+  (PrintWriter a b) <> (PrintWriter x y) = PrintWriter (a ++ x) (b . y)
+
 -- | Output concatenation
 instance Monoid PrintWriter where
   mempty =  PrintWriter [] id
-  mappend (PrintWriter a b) (PrintWriter x y) = PrintWriter (a ++ x) (b . y)
 
 -- | The state of the pretty printer.
 data PrintState = PrintState
@@ -67,10 +70,11 @@ newtype Printer = Printer
 execPrinter :: Printer -> PrintReader -> PrintWriter
 execPrinter (Printer p) r = snd $ execRWS p r defaultPrintState
 
+instance SG.Semigroup Printer where
+  (Printer p) <> (Printer q) = Printer (p >> q)
 
 instance Monoid Printer where
   mempty = Printer $ return ()
-  mappend (Printer p) (Printer q) = Printer (p >> q)
 
 -- | Print some value.
 class Printable a where

--- a/src/haskell-names/Language/Haskell/Names/GlobalSymbolTable.hs
+++ b/src/haskell-names/Language/Haskell/Names/GlobalSymbolTable.hs
@@ -21,6 +21,7 @@ import           Data.Lens.Light
 import qualified Data.Map                           as Map
 import qualified Data.Set                           as Set
 import           Language.Haskell.Exts    as HSE
+import           Data.Semigroup (Semigroup)
 
 -- | Global symbol table — contains global names
 data Table =
@@ -35,9 +36,8 @@ valLens = lens (\(Table vs _) -> vs) (\vs (Table _ ts) -> Table vs ts)
 tyLens :: Lens Table (Map.Map GName (Set.Set (SymTypeInfo OrigName)))
 tyLens = lens (\(Table _ ts) -> ts) (\ts (Table vs _) -> Table vs ts)
 
-instance Monoid Table where
-  mempty = empty
-  mappend (Table vs1 ts1) (Table vs2 ts2) =
+instance Semigroup Table where
+  (Table vs1 ts1) <> (Table vs2 ts2) =
     Table (j vs1 vs2) (j ts1 ts2)
     where
       j :: (Ord i, Ord k)
@@ -45,6 +45,8 @@ instance Monoid Table where
         -> Map.Map k (Set.Set i)
         -> Map.Map k (Set.Set i)
       j = Map.unionWith Set.union
+instance Monoid Table where
+  mempty = empty
 
 toGName :: QName l -> GName
 toGName (UnQual _ n) = GName "" (nameToString n)

--- a/src/haskell-names/Language/Haskell/Names/LocalSymbolTable.hs
+++ b/src/haskell-names/Language/Haskell/Names/LocalSymbolTable.hs
@@ -14,10 +14,11 @@ import           Language.Haskell.Names.Types
 
 import qualified Data.Map                           as Map
 import           Language.Haskell.Exts
+import           Data.Semigroup ()
 
 -- | Local symbol table — contains locally bound names
 newtype Table = Table (Map.Map NameS SrcLoc)
-  deriving Monoid
+  deriving Semigroup
 
 addValue :: SrcInfo l => Name l -> Table -> Table
 addValue n (Table vs) =

--- a/src/haskell-names/Language/Haskell/Names/Open/Derived.hs
+++ b/src/haskell-names/Language/Haskell/Names/Open/Derived.hs
@@ -85,3 +85,5 @@ deriveGTraversable ''PatternSynDirection
 deriveGTraversable ''Unpackedness
 deriveGTraversable ''ResultSig
 deriveGTraversable ''InjectivityInfo
+deriveGTraversable ''DerivStrategy
+deriveGTraversable ''MaybePromotedName

--- a/src/haskell-names/Language/Haskell/Names/Types.hs
+++ b/src/haskell-names/Language/Haskell/Names/Types.hs
@@ -36,6 +36,7 @@ import           Data.Lens.Light
 import qualified Data.Set                                 as Set
 import           Language.Haskell.Exts
 import           Text.Printf
+import qualified Data.Semigroup                           as SG
 
 type ExtensionSet = Set.Set KnownExtension
 
@@ -118,10 +119,12 @@ instance HasOrigName SymTypeInfo where
 data Symbols = Symbols (Set.Set (SymValueInfo OrigName)) (Set.Set (SymTypeInfo OrigName))
   deriving (Eq, Ord, Show, Data, Typeable)
 
+instance SG.Semigroup Symbols where
+  (Symbols s1 t1) <> (Symbols s2 t2) =
+    Symbols (s1 <> s2) (t1 <> t2)
+
 instance Monoid Symbols where
   mempty = Symbols mempty mempty
-  mappend (Symbols s1 t1) (Symbols s2 t2) =
-    Symbols (s1 `mappend` s2) (t1 `mappend` t2)
 
 valSyms :: Lens Symbols (Set.Set (SymValueInfo OrigName))
 valSyms = lens (\(Symbols vs _) -> vs) (\vs (Symbols _ ts) -> Symbols vs ts)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
-resolver: lts-10.2
+resolver: nightly-2018-05-13
 packages:
 - .
 - fay-base
+- language-ecmascript
+allow-newer: true
 extra-deps:
-- language-ecmascript-0.17.2.0
 - spoon-0.3.1
-- testing-feat-0.4.0.3
 - tagshare-0.0
 flags:
   fay:


### PR DESCRIPTION
Hi Adam,

I have quite of bit of code that depends on fay, so when it doesn't
compile with the version of ghc I'm using, I notice.  Well, I couldn't
compile fay with ghc 8.4.2 so I started looking into it.  I discovered
that the culprits where mainly two.  The new Semigroup class and some
new names introduced to haskell-src-exts.  So I added those changes to
fay and found I still couldn't compile because of dependency on
testing-feat in language-ecmascript.  It turns out that testing-feat
is not really required to compile the language, it is just need to run
the tests.  I modified the language-ecmascript.cabal file to pull out
the testing-feat dependency and put it into the test section of the
cabal file and filed a pull request,
https://github.com/jswebtools/language-ecmascript/pull/84, almost a
month ago.  Sadly it has not yet been included in Hackage so I have to
have my own private version of language-ecmascript in order to compile
fay.  I'm included the file fay-language-ecmascript.diff in this pull
request so perhaps you can encourage Andrey
(https://github.com/achudnov) to push it to hackage.  Anyway, after
making all those changes, it now compiles and passes the tests with
nightly-2018-05-13.  I was hoping an lts package that uses ghc 8.4.2
becomes available before I sent this, but so far it hasn't and I need
to move on to other things.  I wish I understood the code you have
written to implement fay better, but it is above my haskell pay grade
at this point.  Anyway, I hope you find this effort helpful in keeping
fay up to date.

Best wishes,
Henry Laxen


PS

I ran the fay.cabal file through cabal-bounds, which completely reformatted the fay.cabal file.  That is why the diff is the entire cabal file.  Sorry.  Also I compiled and ran fay-tests and all of the tests came back OK.
