### PR TITLE
made patterns irrefutable to fix MonadFail errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ ghc:
   - "8.0"
   - "8.2"
   - "8.4"
+  - "8.6"
 install:
   - "travis_retry cabal install 'cpphs >= 1.18.3' 'happy >= 1.19.5'"
   - "cabal install --dry-run -v3"

--- a/fay.cabal
+++ b/fay.cabal
@@ -139,7 +139,7 @@ library
     Language.Haskell.Names.Types
     Paths_fay
   build-depends:
-      base >= 4.9 && < 4.12
+      base >= 4.9 && < 4.13
     , base-compat >= 0.10 && < 0.11
     , aeson > 0.6 && < 1.5
     , bytestring >= 0.9 && < 0.11

--- a/src/Fay/Compiler.hs
+++ b/src/Fay/Compiler.hs
@@ -121,7 +121,7 @@ compileFileWithSource filepath contents = do
 -- | Compile a parse HSE module.
 compileModuleFromAST :: ([JsStmt], [JsStmt]) -> F.Module -> Compile ([JsStmt], [JsStmt])
 compileModuleFromAST (hstmts0, fstmts0) mod'@Module{} = do
-  mod@(Module _ _ pragmas _ decls) <- annotateModule Haskell2010 defaultExtensions mod'
+  ~mod@(Module _ _ pragmas _ decls) <- annotateModule Haskell2010 defaultExtensions mod'
   let modName = unAnn $ F.moduleName mod
   modify $ \s -> s { stateUseFromString = hasLanguagePragmas ["OverloadedStrings", "RebindableSyntax"] pragmas
                    }

--- a/src/Fay/Compiler/Import.hs
+++ b/src/Fay/Compiler/Import.hs
@@ -50,7 +50,7 @@ compileWith filepath with compileModule before from = do
       st
       (parseResult (throwError . uncurry ParseError)
                    (\mod' -> do
-                     mod@(Module _ _ _ imports _) <-
+                     ~mod@(Module _ _ _ imports _) <-
                        either throwError return =<< io (before F.noI mod')
                      res <- foldr (<>) mempty <$> mapM (compileImport compileModule) imports
                      modify $ \s -> s { stateModuleName = unAnn $ F.moduleName mod }

--- a/src/Fay/Compiler/InitialPass.hs
+++ b/src/Fay/Compiler/InitialPass.hs
@@ -51,7 +51,7 @@ preprocessFileWithSource filepath contents = do
 preprocessAST :: () -> F.Module -> Compile ()
 preprocessAST () mod@(Module _ _ _ _ decls) = do
   -- This can only return one element since we only compile one module.
-  ([exports],_) <- HN.getInterfaces Haskell2010 defaultExtensions [mod]
+  ~([exports],_) <- HN.getInterfaces Haskell2010 defaultExtensions [mod]
   modify $ \s -> s { stateInterfaces = M.insert (stateModuleName s) exports $ stateInterfaces s }
   forM_ decls scanTypeSigs
   forM_ decls scanRecordDecls

--- a/src/Fay/Convert.hs
+++ b/src/Fay/Convert.hs
@@ -139,7 +139,7 @@ parseDataOrTuple rec value = result where
 parseTuple :: Data a => GenericParser -> DataType -> Vector Value -> Either String a
 parseTuple rec typ arr =
   case dataTypeConstrs typ of
-    [cons] -> evalStateT (fromConstrM (do i:next <- get
+    [cons] -> evalStateT (fromConstrM (do ~(i:next) <- get
                                           put next
                                           value <- lift (Vector.indexM arr i)
                                           lift (rec value))
@@ -164,7 +164,7 @@ parseObject rec typ obj =
 -- | Make a simple ADT constructor from an object: { "slot1": 1, "slot2": 2} -> Foo 1 2
 makeSimple :: Data a => GenericParser -> HashMap Text Value -> Constr -> Either String a
 makeSimple rec obj cons =
-  evalStateT (fromConstrM (do i:next <- get
+  evalStateT (fromConstrM (do ~(i:next) <- get
                               put next
                               value <- lift (lookupField obj (Text.pack ("slot" ++ show i)))
                               lift (rec value))
@@ -176,7 +176,7 @@ makeRecord :: Data a => GenericParser -> HashMap Text Value -> Constr -> [String
 makeRecord rec obj cons =
   evalStateT $
     fromConstrM
-      (do key:next <- get
+      (do ~(key:next) <- get
           put next
           value <- lift (lookupField obj (Text.pack key))
           lift $ rec value)


### PR DESCRIPTION
ghc 8.6.1 gives errors when compiling fay because of new MonadFail.  This patch fixes those errors.