### PR TITLE
Workaround to make Fay works when using stack nix integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See full history at: <https://github.com/faylang/fay/commits>
 
+#### 0.24.0.4 (2019-12-03)
+
+* Fixes stack nix  integration broken
+
 #### 0.24.0.3 (2019-04-29)
 
 * Dependency updates including GHC-8.6 support.

--- a/fay.cabal
+++ b/fay.cabal
@@ -1,5 +1,5 @@
 name:                fay
-version:             0.24.0.3
+version:             0.24.0.4
 synopsis:            A compiler for Fay, a Haskell subset that compiles to JavaScript.
 description:         Fay is a proper subset of Haskell which is type-checked
                      with GHC, and compiled to JavaScript. It is lazy, pure, has a Fay monad,


### PR DESCRIPTION
When using stack with nix enable, ghc and ghc-pkg might not be
under .stack... something but in the nix store (/nix...).
So we need to use the stack wrapper to be in the correct nix
environment.

However, this pause a problem, as we are alread somehow in
a nix environment (and stack forbid it using the STACK_IN_NIX_SHELL
environment variable). We disable it temporatily and it seem to work.