### PR TITLE
Add support GHC 8.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tests/*.js
 tests/*/*.js
 .stack-work
 .ghc*
+cabal.project.local

--- a/fay.cabal
+++ b/fay.cabal
@@ -139,7 +139,7 @@ library
     Language.Haskell.Names.Types
     Paths_fay
   build-depends:
-      base >= 4.9 && < 4.13
+      base >= 4.9 && < 4.14
     , base-compat >= 0.10 && < 0.11
     , aeson > 0.6 && < 1.5
     , bytestring >= 0.9 && < 0.11
@@ -149,7 +149,7 @@ library
     , directory >= 1.1 && < 1.4
     , filepath >= 1.3 && < 1.5
     , ghc-paths == 0.1.*
-    , haskell-src-exts == 1.20.*
+    , haskell-src-exts >= 1.20
     , language-ecmascript >= 0.15 && < 0.20
     , mtl >= 2.1 && < 2.3
     , mtl-compat >= 0.1 && < 0.3
@@ -181,7 +181,7 @@ executable fay
       base
     , fay
     , mtl
-    , optparse-applicative >= 0.11 && < 0.15
+    , optparse-applicative >= 0.11 && < 0.16
     , split
   other-modules:
     Paths_fay

--- a/src/Fay/Compiler/GADT.hs
+++ b/src/Fay/Compiler/GADT.hs
@@ -9,13 +9,11 @@ import           Language.Haskell.Exts hiding (name)
 -- | Convert a GADT to a normal data type.
 convertGADT :: GadtDecl a -> QualConDecl a
 convertGADT d = case d of
-  GadtDecl s name Nothing typ ->
+  GadtDecl s name tyvars context Nothing typ ->
     QualConDecl s tyvars context (ConDecl s name (convertFunc typ))
-  GadtDecl s name (Just fs) _typ ->
+  GadtDecl s name tyvars context (Just fs) _typ ->
     QualConDecl s tyvars context (RecDecl s name fs)
   where
-    tyvars = Nothing
-    context = Nothing
     convertFunc :: Type a -> [Type a]
     convertFunc (TyCon _ _) = []
     convertFunc (TyFun _ x xs) = x : convertFunc xs

--- a/src/haskell-names/Language/Haskell/Names/GetBound.hs
+++ b/src/haskell-names/Language/Haskell/Names/GetBound.hs
@@ -79,7 +79,7 @@ instance (Data l) => GetBound (QualConDecl l) l where
     getBound ctx (QualConDecl _ _ _ d) = getBound ctx d
 
 instance (Data l) => GetBound (GadtDecl l) l where
-    getBound _ctx (GadtDecl _l conName mbFieldDecls _ty) =
+    getBound _ctx (GadtDecl _l conName _tyvarBinds _context mbFieldDecls _ty) =
       -- GADT constructor name
       [conName] ++
       -- GADT selector names

--- a/src/haskell-names/Language/Haskell/Names/ModuleSymbols.hs
+++ b/src/haskell-names/Language/Haskell/Names/ModuleSymbols.hs
@@ -101,7 +101,7 @@ getTopDeclSymbols impTbl mdl d =
 
         cons :: Constructors
         cons = do -- list monad
-          GadtDecl _ cn (fromMaybe [] -> fields) _ty <- gadtDecls
+          GadtDecl _ cn _tyvarBinds _context (fromMaybe [] -> fields) _ty <- gadtDecls
           return (void cn , [void f | FieldDecl _ fNames _ <- fields, f <- fNames])
 
         infos = constructorsToInfos dq cons

--- a/src/haskell-names/Language/Haskell/Names/Open/Derived.hs
+++ b/src/haskell-names/Language/Haskell/Names/Open/Derived.hs
@@ -47,7 +47,6 @@ deriveGTraversable ''Rhs
 deriveGTraversable ''GuardedRhs
 deriveGTraversable ''Type
 deriveGTraversable ''TyVarBind
--- deriveGTraversable ''Kind
 deriveGTraversable ''FunDep
 deriveGTraversable ''Context
 deriveGTraversable ''Asst

--- a/src/haskell-names/Language/Haskell/Names/Open/Derived.hs
+++ b/src/haskell-names/Language/Haskell/Names/Open/Derived.hs
@@ -47,7 +47,7 @@ deriveGTraversable ''Rhs
 deriveGTraversable ''GuardedRhs
 deriveGTraversable ''Type
 deriveGTraversable ''TyVarBind
-deriveGTraversable ''Kind
+-- deriveGTraversable ''Kind
 deriveGTraversable ''FunDep
 deriveGTraversable ''Context
 deriveGTraversable ''Asst


### PR DESCRIPTION
Closes partially #462.
Details:
- [X] Make `fay` compile with GHC 8.8.
- [x] Resolve build with older GHC 8.x versions.
- [x] Resolve build with older `haskell-src-exts` version (backward compatibility for GHC 8).