### PR TITLE
Relax boundaries to resolve gentoo packaging issue

### DIFF
--- a/fay.cabal
+++ b/fay.cabal
@@ -140,8 +140,8 @@ library
     Paths_fay
   build-depends:
       base >= 4.9 && < 4.15
-    , base-compat >= 0.10 && < 0.11
-    , aeson > 0.6 && < 1.5
+    , base-compat >= 0.10 && < 0.12
+    , aeson > 0.6 && < 1.6
     , bytestring >= 0.9 && < 0.11
     , containers >= 0.4 && < 0.7
     , data-default >= 0.2 && < 0.8
@@ -208,8 +208,8 @@ executable fay-tests
       , fay
       , filepath
       , haskell-src-exts
-      , random >= 1.0 && < 1.2
-      , tasty >= 0.9 && < 1.2
+      , random >= 1.0 && < 1.3
+      , tasty >= 0.9 && < 1.5
       , tasty-hunit >= 0.8 && < 0.11
       , tasty-th == 0.1.*
       , text


### PR DESCRIPTION
Relax boundaries for following packages allowing packaging issue on Gentoo:

- aeson
- base-compat
- tasty
- random