### PR TITLE
Relax version bounds on optparse-applicative

### DIFF
--- a/fay.cabal
+++ b/fay.cabal
@@ -186,7 +186,7 @@ executable fay
       base
     , fay
     , mtl
-    , optparse-applicative >= 0.11 && < 0.16
+    , optparse-applicative >= 0.11 && < 0.17
     , split
   other-modules:
     Paths_fay


### PR DESCRIPTION
Confirmed that fay compiles with 0.16.1.0

A new release with this change would be appreciated!