### PR TITLE
Add GHC 9.0 support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,12 @@
 packages: . fay-base/
+
+allow-newer: language-ecmascript:base
+
+source-repository-package
+    type: git
+    location: https://github.com/swamp-agr/traverse-with-class
+
+source-repository-package
+    type: git
+    location: https://github.com/sorki/data-lens-light
+    tag: db75ed52810293013da577d72fbfb502273ef02e

--- a/fay.cabal
+++ b/fay.cabal
@@ -143,7 +143,7 @@ library
     Language.Haskell.Names.Types
     Paths_fay
   build-depends:
-      base >= 4.9 && < 4.15
+      base >= 4.9 && < 4.16
     , base-compat >= 0.10 && < 0.12
     , aeson > 0.6 && < 1.6
     , bytestring >= 0.9 && < 0.11
@@ -191,34 +191,32 @@ executable fay
   other-modules:
     Paths_fay
 
-executable fay-tests
+test-suite fay-tests
   default-language:  Haskell2010                           
   ghc-options:       -O2 -Wall -threaded -with-rtsopts=-N
   hs-source-dirs:    src/tests
+  type:              exitcode-stdio-1.0
   main-is:           Tests.hs
-  if flag(test)
-    other-modules:
-      Test.CommandLine
-      Test.Compile
-      Test.Convert
-      Test.Desugar
-      Test.Util
-      Paths_fay
-    build-depends:
-        base
-      , aeson
-      , attoparsec
-      , bytestring
-      , containers
-      , directory
-      , fay
-      , filepath
-      , haskell-src-exts
-      , random >= 1.0 && < 1.3
-      , tasty >= 0.9 && < 1.5
-      , tasty-hunit >= 0.8 && < 0.11
-      , tasty-th == 0.1.*
-      , text
-      , utf8-string
-  else
-    buildable:         False
+  other-modules:
+    Test.CommandLine
+    Test.Compile
+    Test.Convert
+    Test.Desugar
+    Test.Util
+    Paths_fay
+  build-depends:
+      base
+    , aeson
+    , attoparsec
+    , bytestring
+    , containers
+    , directory
+    , fay
+    , filepath
+    , haskell-src-exts
+    , random >= 1.0 && < 1.3
+    , tasty >= 0.9 && < 1.5
+    , tasty-hunit >= 0.8 && < 0.11
+    , tasty-th == 0.1.*
+    , text
+    , utf8-string

--- a/src/Fay/Convert.hs
+++ b/src/Fay/Convert.hs
@@ -37,8 +37,8 @@ import qualified Data.Vector           as Vector
 -- | Convert a Haskell value to a Fay json value.  This can fail when primitive
 --   values aren't handled by explicit cases.  'encodeFay' can be used to
 --   resolve this issue.
-showToFay :: Data a => a -> Maybe Value
-showToFay = spoon . encodeFay id
+showToFay :: forall a. Data a => a -> Maybe Value
+showToFay v = spoon $ encodeFay (\f -> f) v
 
 -- | Convert a Haskell value to a Fay json value.  This can fail when primitive
 --   values aren't handled by explicit cases.  When this happens, you can add

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,10 @@
-resolver: lts-12.7
+resolver: lts-16.28
 packages:
 - .
 - fay-base
 allow-newer: true
+extra-deps:
+- language-ecmascript-0.19.1.0
 flags:
   fay:
     test: true


### PR DESCRIPTION
- Add experimental GHC 9.0 support (only for cabal v2-builds).